### PR TITLE
✨ Support the optional `custom_request_headers` field for `google.cloudRun` services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support the optional `custom_request_headers` field for `google.cloudRun` services.
+
 ## v0.1.1 (2024-02-21)
 
 Chores:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ module "my_api_router" {
 
       # The name of the Cloud Run service.
       service = "my-cloud-run-service"
+
+      # A list of custom headers added by the Google Front End to all incoming requests.
+      # See https://cloud.google.com/load-balancing/docs/https/custom-headers.
+      custom_request_headers = [
+        "X-My-Header:{client_protocol}",
+      ]
     }
   }
 }

--- a/backend-cloud-run.tf
+++ b/backend-cloud-run.tf
@@ -37,6 +37,8 @@ resource "google_compute_backend_service" "cloud_run_service" {
   name                  = "run-${each.key}"
   load_balancing_scheme = "EXTERNAL_MANAGED"
 
+  custom_request_headers = try(local.cloud_run_services[each.key].custom_request_headers, [])
+
   backend {
     group = each.value.id
   }

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,9 @@ variable "services" {
     region = optional(string)
     # The name of the Cloud Run service to expose.
     service = optional(string)
+    # Custom request headers set by the Google Front End.
+    # See https://cloud.google.com/load-balancing/docs/https/custom-headers.
+    custom_request_headers = optional(set(string))
   }))
   description = "A map where values define the services exposed by the router."
 }


### PR DESCRIPTION
- **✨ Support setting custom request headers in the backend configurations**
- **📝 Update changelog**
- **📝 Document the custom_request_headers option**
