### PR TITLE
🔖 Prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.0 (2024-04-25)
+
 Features:
 
 - Support the optional `custom_request_headers` field for `google.cloudRun` services.


### PR DESCRIPTION
Features:

- Support the optional `custom_request_headers` field for `google.cloudRun` services.

### Commits

- **🔖 Prepare v0.2.0**