### PR TITLE
🔖 Prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.0 (2024-08-30)
+
 Breaking changes:
 
 - Drop support for Google provider `< 6.0.0` and support `6.*.*`.


### PR DESCRIPTION
Breaking changes:

- Drop support for Google provider `< 6.0.0` and support `6.*.*`.

Chores:

- Explicitly disable Identity-Aware Proxy.

### Commits

- **📝 Update changelog**