### PR TITLE
🐛 Filter out Cloud Run services with no path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Filter out Cloud Run services with no path to prevent errors when creating URL maps.
+
 ## v0.3.1 (2025-09-12)
 
 Chores:

--- a/backend-cloud-run.tf
+++ b/backend-cloud-run.tf
@@ -37,12 +37,6 @@ resource "google_compute_backend_service" "cloud_run_service" {
   name                  = "run-${each.key}"
   load_balancing_scheme = "EXTERNAL_MANAGED"
 
-  # Although optional, not explicitly disabling the Identity-Aware Proxy can cause unnecessary diffs in Terraform plans.
-  # https://github.com/hashicorp/terraform-provider-google/issues/19273
-  iap {
-    enabled = false
-  }
-
   custom_request_headers = try(local.cloud_run_services[each.key].custom_request_headers, [])
 
   backend {

--- a/backend-cloud-run.tf
+++ b/backend-cloud-run.tf
@@ -2,7 +2,7 @@ locals {
   cloud_run_services = {
     for name, definition in var.services :
     name => definition
-    if definition.type == "google.cloudRun"
+    if definition.type == "google.cloudRun" && length(definition.paths) > 0
   }
 
   cloud_run_path_rules = {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.0.1, < 8.0"
+      version = ">= 6.4.0, < 8.0"
     }
   }
 }


### PR DESCRIPTION
This also removes a previous workaround for https://github.com/hashicorp/terraform-provider-google/issues/19273.
